### PR TITLE
Feature: send info email without personal data

### DIFF
--- a/Configuration/TypoScript/constants.typoscript
+++ b/Configuration/TypoScript/constants.typoscript
@@ -11,6 +11,9 @@ plugin.tx_jobapplications.settings {
 	# cat=plugin.tx_jobapplications; type=options[html,plain,both]; label=Send Email as HTML or Text or Both
 	emailContentType = both
 
+	# cat=plugin.tx_jobapplications; type=boolean; label=Send email without any personal application data (privacy protection)
+	emailPrivacyMode = 0
+
 	# cat=plugin.tx_jobapplications; type=string; label=Default contact (mail address) for unsolicited application form mail
 	defaultContactMailAddress = address@address.de
 	# cat=plugin.tx_jobapplications; type=string; label=Default contact (first name) for unsolicited application form mail

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -31,6 +31,7 @@ plugin.tx_jobapplications {
 		fileStorage = {$plugin.tx_jobapplications.settings.fileStorage}
 		enableGoogleJobs = {$plugin.tx_jobapplications.settings.enableGoogleJobs}
 		emailContentType = {$plugin.tx_jobapplications.settings.emailContentType}
+		emailPrivacyMode = {$plugin.tx_jobapplications.settings.emailPrivacyMode}
 		legacy_upload = {$plugin.tx_jobapplications.settings.legacy_upload}
 		defaultContactMailAddress = {$plugin.tx_jobapplications.settings.defaultContactMailAddress}
 		defaultContactFirstName = {$plugin.tx_jobapplications.settings.defaultContactFirstName}

--- a/Documentation/User/Index.rst
+++ b/Documentation/User/Index.rst
@@ -308,6 +308,10 @@ Send Email as HTML or Text or Both
 This setting only has an effect in TYPO3 v10. You can choose to send out emails as their html, text or both combined versions.
 There are email templates, for both the html and text versions.
 
+Send email without any personal application data (privacy protection)
+----------------------------------
+To avoid privacy issues, we recommend enabling this feature. When this function is enabled, only information about a new application without personal data is sent as an email.
+
 Enable Google Jobs
 ------------------
 Here you can enable Google Jobs. The data for it will be automatically generated based on the posting data.

--- a/Resources/Private/Language/de.locallang_backend.xlf
+++ b/Resources/Private/Language/de.locallang_backend.xlf
@@ -343,7 +343,11 @@
             </trans-unit>
             <trans-unit id="be.widget_group.jobapplications" resname="be.widget_group.jobapplications">
                 <source>Jobs</source>
-                <source>Stellenausschreibungen</source>
+                <target>Stellenausschreibungen</target>
+            </trans-unit>
+            <trans-unit id="be.review_in_backend" resname="be.review_in_backend">
+                <source>You can review this new application in your website's TYPO3 backend.</source>
+                <target>Sie finden diese Bewerbung im TYPO3 Backend Ihrer Website</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/Private/Language/locallang_backend.xlf
+++ b/Resources/Private/Language/locallang_backend.xlf
@@ -267,6 +267,9 @@
             <trans-unit id="be.widget_group.jobapplications" resname="be.widget_group.jobapplications">
                 <source>Jobs</source>
             </trans-unit>
+            <trans-unit id="be.review_in_backend" resname="be.review_in_backend">
+                <source>You can review this new application in your website's TYPO3 backend.</source>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Templates/Mail/JobsInfoMail.html
+++ b/Resources/Private/Templates/Mail/JobsInfoMail.html
@@ -1,0 +1,16 @@
+<f:layout name="SystemEmail"/>
+<f:section name="Title">
+	<f:if condition="!{application.posting}">
+		<f:then>
+			{currentPosting.title}
+		</f:then>
+		<f:else>
+			<f:translate arguments="{0: currentPosting.title}" extensionName="Jobapplications" id="fe.email.toContactSubject"></f:translate>
+		</f:else>
+	</f:if>
+</f:section>
+<f:section name="Main">
+	<div class="row">
+		<f:translate key="LLL:EXT:jobapplications/Resources/Private/Language/locallang_backend.xlf:be.review_in_backend"/>
+	</div>
+</f:section>

--- a/Resources/Private/Templates/Mail/JobsInfoMail.txt
+++ b/Resources/Private/Templates/Mail/JobsInfoMail.txt
@@ -1,0 +1,3 @@
+<f:translate key="LLL:EXT:jobapplications/Resources/Private/Language/locallang.xlf:tx_jobapplications_domain_model_application.posting"></f:translate>: <f:if condition="!{application.posting}"><f:then><f:translate key="LLL:EXT:jobapplications/Resources/Private/Language/locallang_backend.xlf:be.filter.unsolicited.single"/></f:then><f:else>{application.posting.title}</f:else></f:if>
+
+<f:translate key="LLL:EXT:jobapplications/Resources/Private/Language/locallang_backend.xlf:be.review_in_backend"/>


### PR DESCRIPTION
Sending an email with all application data is not GDPR compliant. I added a typoscript switch to enable a GDPR compliant email info without any personal data.