### PR TITLE
Unknown column 'cruser_id' in 'field list'

### DIFF
--- a/Classes/Controller/ApplicationController.php
+++ b/Classes/Controller/ApplicationController.php
@@ -678,7 +678,6 @@
 					[
 						'tstamp' => time(),
 						'crdate' => time(),
-						'cruser_id' => 1,
 						'uid_local' => $fileUid,
 						'uid_foreign' => $objectUid,
 						'tablenames' => "tx_jobapplications_domain_model_application",


### PR DESCRIPTION
Version 3.0.1

table_local seem to be wrong also.