### PR TITLE
Drop cached default date from postings

### DIFF
--- a/Configuration/TCA/tx_jobapplications_domain_model_posting.php
+++ b/Configuration/TCA/tx_jobapplications_domain_model_posting.php
@@ -75,7 +75,6 @@ return [
                 'type' => 'input',
                 'renderType' => 'inputDateTime',
                 'eval' => 'datetime,int',
-                'default' => time(),
                 'behaviour' => [
                     'allowLanguageSynchronization' => true
                 ]
@@ -119,7 +118,6 @@ return [
                 'renderType' => 'inputDateTime',
                 'size' => 7,
                 'eval' => 'date,required',
-                'default' => time()
             ],
         ],
         'career_level' => [


### PR DESCRIPTION
TCA is cached, so setting a "default" date is not possible here anymore. The default date would otherwise always be the date from when the TCA cache entry was written.