### PR TITLE
Access files in application notification mails

### DIFF
--- a/Classes/Controller/ApplicationController.php
+++ b/Classes/Controller/ApplicationController.php
@@ -483,6 +483,11 @@
 							$mail->attachFromPath($file->getForLocalProcessing(false));
 						}
 					}
+
+					$mail->assignMultiple([
+						'legacyUploadfiles' => $legacyUploadfiles,
+						'multiUploadFiles' => $multiUploadFiles,
+					]);
 				}
 
 				//Figure out who the email will be sent to and how


### PR DESCRIPTION
This assigns the processed legacy and multi-upload files to the job application notification mail. This allows custom mail templates to e.g. list the filenames and other details.

For separation/grouping of files, see https://github.com/itx-informationssysteme/jobapplications/pull/156