### PR TITLE
Include Sitesets for TYPO3 13 to include typoscript

### DIFF
--- a/Configuration/Sets/IncludeBootstrap/config.yaml
+++ b/Configuration/Sets/IncludeBootstrap/config.yaml
@@ -1,0 +1,3 @@
+# EXT:jobapplications/Configuration/Sets/Jobapplications/config.yaml
+name: itx/bootstrap
+label: 'Jobapplications - Bootstrap'

--- a/Configuration/Sets/IncludeBootstrap/constants.typoscript
+++ b/Configuration/Sets/IncludeBootstrap/constants.typoscript
@@ -1,0 +1,5 @@
+plugin.tx_jobapplications {
+
+	# cat=plugin.tx_jobapplications; type=string; label=Css file path
+	bootstrapPath = EXT:jobapplications/Resources/Public/Css/Vendor/bootstrap.min.css
+}

--- a/Configuration/Sets/IncludeBootstrap/setup.typoscript
+++ b/Configuration/Sets/IncludeBootstrap/setup.typoscript
@@ -1,0 +1,1 @@
+page.includeCSS.path = {$plugin.tx_jobapplications.bootstrapPath}

--- a/Configuration/Sets/IncludeJQuery/config.yaml
+++ b/Configuration/Sets/IncludeJQuery/config.yaml
@@ -1,0 +1,3 @@
+# EXT:jobapplications/Configuration/Sets/Jobapplications/config.yaml
+name: itx/jquery
+label: 'Jobapplications - jQuery for Filters'

--- a/Configuration/Sets/IncludeJQuery/constants.typoscript
+++ b/Configuration/Sets/IncludeJQuery/constants.typoscript
@@ -1,0 +1,5 @@
+plugin.tx_jobapplications {
+
+	# cat=plugin.tx_jobapplications; type=string; label=JQuery path
+	jqueryPath = EXT:jobapplications/Resources/Public/Js/Vendor/jquery-3.5.1.min.js
+}

--- a/Configuration/Sets/IncludeJQuery/setup.typoscript
+++ b/Configuration/Sets/IncludeJQuery/setup.typoscript
@@ -1,0 +1,1 @@
+page.includeJSLibs.path = {$plugin.tx_jobapplications.jqueryPath}

--- a/Configuration/Sets/Jobapplications/config.yaml
+++ b/Configuration/Sets/Jobapplications/config.yaml
@@ -1,0 +1,3 @@
+# EXT:jobapplications/Configuration/Sets/Jobapplications/config.yaml
+name: itx/jobapplications
+label: 'Jobapplications Basic Site Set'

--- a/Configuration/Sets/Jobapplications/constants.typoscript
+++ b/Configuration/Sets/Jobapplications/constants.typoscript
@@ -1,0 +1,2 @@
+# EXT:jobapplications/Configuration/Sets/Jobapplications/constants.typoscript
+@import 'EXT:jobapplications/Configuration/TypoScript/constants.typoscript'

--- a/Configuration/Sets/Jobapplications/setup.typoscript
+++ b/Configuration/Sets/Jobapplications/setup.typoscript
@@ -1,0 +1,2 @@
+# EXT:jobapplications/Configuration/Sets/Jobapplications/setup.typoscript
+@import 'EXT:jobapplications/Configuration/TypoScript/setup.typoscript'


### PR DESCRIPTION
The necessary typoscript files which were previously integrated via the sys_template.php are integrated with this pull request via sitesets, because in the symlink based TYPO3 13 there is no possibility to integrate the necessary typoscript files into the TYPO3 instance as before.